### PR TITLE
Added new verb Purchased

### DIFF
--- a/public_html/seriousgames.jsonld
+++ b/public_html/seriousgames.jsonld
@@ -349,6 +349,22 @@
       }
     },
     {
+      "@id": "https://w3id.org/xapi/seriousgames/verbs/purchased",
+      "@type": "Verb",
+      "definition": {
+        "en": "Indicates that the actor has made a real or virtual purchase within the application."
+      },
+      "prefLabel": {
+        "en": "purchased"
+      },
+      "scopeNote": {
+        "en": "Used when the player make an in-app purchase with real or virtual currencies."
+      },
+      "closelyRelatedNaturalLanguageTerm": {
+        "@id": "http://http://wordnet-rdf.princeton.edu/id/02211988-v"
+      }
+    },
+    {
       "@id": "https://w3id.org/xapi/seriousgames/verbs/released",
       "@type": "Verb",
       "closeMatch": {


### PR DESCRIPTION
ADL suggested that this should be in this profile as opposed to the pending GBLxAPI profile.  We are currently using this verb in xAPI collection in games.  We believe this should be a community verb as it is a common activity.  We have followed your format which may or may not meet current requirements.